### PR TITLE
chore(fmt): run `cargo fmt`

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -108,7 +108,7 @@ fn default_true() -> bool {
 }
 
 fn default_burn_method() -> String {
-    "direct".to_string()  // Default to direct method for space efficiency
+    "direct".to_string() // Default to direct method for space efficiency
 }
 
 impl Default for Config {
@@ -191,19 +191,21 @@ impl Config {
         // Validate device path - try auto-detection if default doesn't work
         let device_path = Path::new(&self.device);
         if device_path.exists() {
-            paths::validate_device(device_path)
-                .with_context(|| {
-                    // Suggest auto-detected device if validation fails
-                    let suggestion = paths::detect_optical_drive()
-                        .filter(|d| d != &self.device)
-                        .map(|d| format!("\n\n💡 Suggestion: Use auto-detected drive: {}", d))
-                        .unwrap_or_default();
-                    format!("Invalid device path: {}{}", self.device, suggestion)
-                })?;
+            paths::validate_device(device_path).with_context(|| {
+                // Suggest auto-detected device if validation fails
+                let suggestion = paths::detect_optical_drive()
+                    .filter(|d| d != &self.device)
+                    .map(|d| format!("\n\n💡 Suggestion: Use auto-detected drive: {}", d))
+                    .unwrap_or_default();
+                format!("Invalid device path: {}{}", self.device, suggestion)
+            })?;
         } else {
             // Device doesn't exist - try auto-detection
             if let Some(auto_device) = paths::detect_optical_drive() {
-                info!("Auto-detected optical drive: {} (instead of {})", auto_device, self.device);
+                info!(
+                    "Auto-detected optical drive: {} (instead of {})",
+                    auto_device, self.device
+                );
                 self.device = auto_device;
             } else {
                 return Err(anyhow::anyhow!(

--- a/src/disc.rs
+++ b/src/disc.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
+use rusqlite::params;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::debug;
-use rusqlite::params;
 
 /// Generate a disc ID in the format YYYY-BD-###.
 pub fn generate_disc_id() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,9 @@ impl App {
                     Err(mpsc::TryRecvError::Disconnected) => {
                         // Background thread died unexpectedly
                         if let AppState::NewDisc(ref mut flow) = self.state {
-                            flow.set_error("Background process terminated unexpectedly".to_string());
+                            flow.set_error(
+                                "Background process terminated unexpectedly".to_string(),
+                            );
                             self.disc_creation_rx = None;
                             updated = true;
                         }
@@ -173,10 +175,16 @@ impl App {
                     KeyCode::Esc => {
                         if flow.current_step() == tui::new_disc::NewDiscStep::Processing {
                             // Check if processing is complete - allow escape then
-                            if matches!(flow.processing_state(), tui::new_disc::ProcessingState::Complete) {
+                            if matches!(
+                                flow.processing_state(),
+                                tui::new_disc::ProcessingState::Complete
+                            ) {
                                 self.state = AppState::MainMenu;
                                 return Ok(true);
-                            } else if matches!(flow.processing_state(), tui::new_disc::ProcessingState::Error(_)) {
+                            } else if matches!(
+                                flow.processing_state(),
+                                tui::new_disc::ProcessingState::Error(_)
+                            ) {
                                 // Allow escape on error too - go back to review
                                 flow.previous_step();
                                 flow.clear_error();
@@ -320,12 +328,17 @@ impl App {
                                         Err(e) => {
                                             // Failed burn - attempt to cleanup staging directory
                                             warn!("Disc creation failed: {}", e);
-                                            let _ = tx.send(DiscCreationMessage::Error(format!("Disc creation failed: {}", e)));
+                                            let _ = tx.send(DiscCreationMessage::Error(format!(
+                                                "Disc creation failed: {}",
+                                                e
+                                            )));
 
                                             if !dry_run {
                                                 // Try to cleanup staging directory even on failure
                                                 if let Ok(staging_dir) = config.staging_dir() {
-                                                    let _ = Self::cleanup_staging_directory(&staging_dir);
+                                                    let _ = Self::cleanup_staging_directory(
+                                                        &staging_dir,
+                                                    );
                                                 }
                                             }
                                         }
@@ -1041,7 +1054,9 @@ impl App {
         use std::time::Duration;
 
         if dry_run {
-            let _ = tx.send(DiscCreationMessage::Progress("DRY RUN: Would burn ISO to disc".to_string()));
+            let _ = tx.send(DiscCreationMessage::Progress(
+                "DRY RUN: Would burn ISO to disc".to_string(),
+            ));
             thread::sleep(Duration::from_millis(500));
             return Ok(());
         }
@@ -1061,11 +1076,16 @@ impl App {
         };
 
         // Phase 1: Initializing burn
-        let _ = tx.send(DiscCreationMessage::Progress("🔥 Initializing Blu-ray burner...".to_string()));
+        let _ = tx.send(DiscCreationMessage::Progress(
+            "🔥 Initializing Blu-ray burner...".to_string(),
+        ));
         thread::sleep(Duration::from_millis(500));
 
         // Phase 2: Starting data transfer with size info
-        let _ = tx.send(DiscCreationMessage::Progress(format!("💿 Starting data transfer ({}GB) to disc...", iso_size_gb)));
+        let _ = tx.send(DiscCreationMessage::Progress(format!(
+            "💿 Starting data transfer ({}GB) to disc...",
+            iso_size_gb
+        )));
         thread::sleep(Duration::from_millis(500));
 
         // Start progress monitoring thread
@@ -1087,16 +1107,20 @@ impl App {
                 if burn_progress != last_progress && burn_progress < 95 {
                     let speed_mbs = if elapsed > 0.0 {
                         (iso_size as f64 / elapsed / 1_000_000.0) as u32
-                    } else { 0 };
+                    } else {
+                        0
+                    };
 
                     let eta_mins = if progress_ratio > 0.0 {
                         ((1.0 - progress_ratio) * estimated_burn_time_secs / 60.0) as u32
-                    } else { 0 };
+                    } else {
+                        0
+                    };
 
-                    let _ = progress_tx.send(DiscCreationMessage::Progress(
-                        format!("🔥 Burning... {}MB/s | {}min remaining | {}% complete",
-                               speed_mbs, eta_mins, burn_progress)
-                    ));
+                    let _ = progress_tx.send(DiscCreationMessage::Progress(format!(
+                        "🔥 Burning... {}MB/s | {}min remaining | {}% complete",
+                        speed_mbs, eta_mins, burn_progress
+                    )));
                     last_progress = burn_progress;
                 }
 
@@ -1110,12 +1134,15 @@ impl App {
                 let burn_duration = start_time.elapsed();
                 let actual_speed = if burn_duration.as_secs_f64() > 0.0 {
                     (iso_size as f64 / burn_duration.as_secs_f64() / 1_000_000.0) as u32
-                } else { 0 };
+                } else {
+                    0
+                };
 
-                let _ = tx.send(DiscCreationMessage::Progress(
-                    format!("✅ Burn completed! {:.1}s | {}MB/s average speed",
-                           burn_duration.as_secs_f64(), actual_speed)
-                ));
+                let _ = tx.send(DiscCreationMessage::Progress(format!(
+                    "✅ Burn completed! {:.1}s | {}MB/s average speed",
+                    burn_duration.as_secs_f64(),
+                    actual_speed
+                )));
                 thread::sleep(Duration::from_millis(500));
                 Ok(())
             }
@@ -1176,7 +1203,9 @@ impl App {
         use std::time::Duration;
 
         if dry_run {
-            let _ = tx.send(DiscCreationMessage::Progress("DRY RUN: Would burn directory directly to disc".to_string()));
+            let _ = tx.send(DiscCreationMessage::Progress(
+                "DRY RUN: Would burn directory directly to disc".to_string(),
+            ));
             thread::sleep(Duration::from_millis(500));
             return Ok(());
         }
@@ -1193,11 +1222,16 @@ impl App {
         };
 
         // Phase 1: Initializing burn
-        let _ = tx.send(DiscCreationMessage::Progress("🔥 Initializing Blu-ray burner...".to_string()));
+        let _ = tx.send(DiscCreationMessage::Progress(
+            "🔥 Initializing Blu-ray burner...".to_string(),
+        ));
         thread::sleep(Duration::from_millis(500));
 
         // Phase 2: Starting data transfer with size info
-        let _ = tx.send(DiscCreationMessage::Progress(format!("💿 Starting direct data transfer ({}GB) to disc...", dir_size_gb)));
+        let _ = tx.send(DiscCreationMessage::Progress(format!(
+            "💿 Starting direct data transfer ({}GB) to disc...",
+            dir_size_gb
+        )));
         thread::sleep(Duration::from_millis(500));
 
         // Start progress monitoring thread
@@ -1219,16 +1253,20 @@ impl App {
                 if burn_progress != last_progress && burn_progress < 95 {
                     let speed_mbs = if elapsed > 0.0 {
                         (dir_size as f64 / elapsed / 1_000_000.0) as u32
-                    } else { 0 };
+                    } else {
+                        0
+                    };
 
                     let eta_mins = if progress_ratio > 0.0 {
                         ((1.0 - progress_ratio) * estimated_burn_time_secs / 60.0) as u32
-                    } else { 0 };
+                    } else {
+                        0
+                    };
 
-                    let _ = progress_tx.send(DiscCreationMessage::Progress(
-                        format!("🔥 Burning... {}MB/s | {}min remaining | {}% complete",
-                               speed_mbs, eta_mins, burn_progress)
-                    ));
+                    let _ = progress_tx.send(DiscCreationMessage::Progress(format!(
+                        "🔥 Burning... {}MB/s | {}min remaining | {}% complete",
+                        speed_mbs, eta_mins, burn_progress
+                    )));
                     last_progress = burn_progress;
                 }
 
@@ -1242,18 +1280,24 @@ impl App {
                 let burn_duration = start_time.elapsed();
                 let actual_speed = if burn_duration.as_secs_f64() > 0.0 {
                     (dir_size as f64 / burn_duration.as_secs_f64() / 1_000_000.0) as u32
-                } else { 0 };
+                } else {
+                    0
+                };
 
-                let _ = tx.send(DiscCreationMessage::Progress(
-                    format!("✅ Direct burn completed! {:.1}s | {}MB/s average speed",
-                           burn_duration.as_secs_f64(), actual_speed)
-                ));
+                let _ = tx.send(DiscCreationMessage::Progress(format!(
+                    "✅ Direct burn completed! {:.1}s | {}MB/s average speed",
+                    burn_duration.as_secs_f64(),
+                    actual_speed
+                )));
                 thread::sleep(Duration::from_millis(500));
                 Ok(())
             }
             Err(e) => {
                 error!("Direct burn failed: {}", e);
-                let _ = tx.send(DiscCreationMessage::Error(format!("Direct burn failed: {}", e)));
+                let _ = tx.send(DiscCreationMessage::Error(format!(
+                    "Direct burn failed: {}",
+                    e
+                )));
                 Err(anyhow::anyhow!("Direct burn failed: {}", e))
             }
         }
@@ -1272,24 +1316,31 @@ impl App {
     ) -> Result<()> {
         let created_at = format_timestamp_now();
 
-        let source_roots_json = serde_json::to_string(source_roots)
-            .context("Failed to serialize source roots")?;
+        let source_roots_json =
+            serde_json::to_string(source_roots).context("Failed to serialize source roots")?;
 
         let disc_record = database::Disc {
             disc_id: disc_id.to_string(),
             volume_label: volume_label.to_string(),
             created_at: created_at.clone(),
-            notes: if notes.is_empty() { None } else { Some(notes.to_string()) },
+            notes: if notes.is_empty() {
+                None
+            } else {
+                Some(notes.to_string())
+            },
             iso_size: Some(iso_size),
-            burn_device: if dry_run { None } else { Some(device.to_string()) },
+            burn_device: if dry_run {
+                None
+            } else {
+                Some(device.to_string())
+            },
             checksum_manifest_hash: None,
             qr_path: None,
             source_roots: Some(source_roots_json),
             tool_version: Some(disc::get_tool_version()),
         };
 
-        database::Disc::insert(db_conn, &disc_record)
-            .context("Failed to insert disc record")?;
+        database::Disc::insert(db_conn, &disc_record).context("Failed to insert disc record")?;
 
         Ok(())
     }
@@ -1394,7 +1445,7 @@ impl App {
             &source_folders,
             use_rsync,
             dry_run,
-            Some(Box::new(staging_progress_callback))
+            Some(Box::new(staging_progress_callback)),
         )?;
         let _ = tx.send(DiscCreationMessage::StateAndStatus(
             tui::new_disc::ProcessingState::Staging,
@@ -1417,7 +1468,7 @@ impl App {
             &disc_root,
             None,
             Some(Box::new(progress_callback)),
-            true // fast_mode = true (uses CRC32 instead of SHA256)
+            true, // fast_mode = true (uses CRC32 instead of SHA256)
         )?;
 
         // Write manifest files
@@ -1426,7 +1477,10 @@ impl App {
             Ok(_) => info!("Manifest file written successfully"),
             Err(e) => {
                 error!("Failed to write manifest file: {}", e);
-                let _ = tx.send(DiscCreationMessage::Error(format!("Failed to write manifest: {}", e)));
+                let _ = tx.send(DiscCreationMessage::Error(format!(
+                    "Failed to write manifest: {}",
+                    e
+                )));
                 return Err(anyhow::anyhow!("Failed to write manifest file: {}", e));
             }
         }
@@ -1436,7 +1490,10 @@ impl App {
             Ok(_) => info!("SHA256SUMS file written successfully"),
             Err(e) => {
                 error!("Failed to write SHA256SUMS file: {}", e);
-                let _ = tx.send(DiscCreationMessage::Error(format!("Failed to write checksums: {}", e)));
+                let _ = tx.send(DiscCreationMessage::Error(format!(
+                    "Failed to write checksums: {}",
+                    e
+                )));
                 return Err(anyhow::anyhow!("Failed to write SHA256SUMS file: {}", e));
             }
         }
@@ -1453,7 +1510,10 @@ impl App {
             Ok(_) => info!("Disc info written successfully"),
             Err(e) => {
                 error!("Failed to write disc info: {}", e);
-                let _ = tx.send(DiscCreationMessage::Error(format!("Failed to write disc info: {}", e)));
+                let _ = tx.send(DiscCreationMessage::Error(format!(
+                    "Failed to write disc info: {}",
+                    e
+                )));
                 return Err(anyhow::anyhow!("Failed to write disc info: {}", e));
             }
         }
@@ -1471,7 +1531,11 @@ impl App {
             let _ = tx.send(DiscCreationMessage::Error(error_msg.clone()));
             return Err(anyhow::anyhow!("{}", error_msg));
         }
-        info!("Capacity check passed: {:.2} GB / {:.2} GB", total_size as f64 / 1_000_000_000.0, capacity as f64 / 1_000_000_000.0);
+        info!(
+            "Capacity check passed: {:.2} GB / {:.2} GB",
+            total_size as f64 / 1_000_000_000.0,
+            capacity as f64 / 1_000_000_000.0
+        );
 
         // Step 4: Create ISO (skip if using direct burn and not dry run)
         let volume_label = disc::generate_volume_label(&disc_id);
@@ -1483,7 +1547,10 @@ impl App {
             iso_size = manifest::calculate_total_size(&files); // Use directory size
             let _ = tx.send(DiscCreationMessage::StateAndStatus(
                 tui::new_disc::ProcessingState::CreatingISO,
-                format!("Direct burn - skipping ISO creation ({:.2} GB)", iso_size as f64 / 1_000_000_000.0),
+                format!(
+                    "Direct burn - skipping ISO creation ({:.2} GB)",
+                    iso_size as f64 / 1_000_000_000.0
+                ),
             ));
         } else {
             let _ = tx.send(DiscCreationMessage::StateAndStatus(
@@ -1502,14 +1569,20 @@ impl App {
                         }
                         Err(e) => {
                             error!("Failed to get ISO size after creation: {}", e);
-                            let _ = tx.send(DiscCreationMessage::Error(format!("Failed to verify ISO size: {}", e)));
+                            let _ = tx.send(DiscCreationMessage::Error(format!(
+                                "Failed to verify ISO size: {}",
+                                e
+                            )));
                             return Err(anyhow::anyhow!("Failed to get ISO size: {}", e));
                         }
                     }
                 }
                 Err(e) => {
                     error!("ISO creation failed: {}", e);
-                    let _ = tx.send(DiscCreationMessage::Error(format!("ISO creation failed: {}", e)));
+                    let _ = tx.send(DiscCreationMessage::Error(format!(
+                        "ISO creation failed: {}",
+                        e
+                    )));
                     return Err(anyhow::anyhow!("ISO creation failed: {}", e));
                 }
             }
@@ -1536,21 +1609,25 @@ impl App {
                 let volume_label = disc::generate_volume_label(&disc_id);
                 info!("Creating ISO for dry run at: {}", iso_path.display());
                 match iso::create_iso(&disc_root, &iso_path, &volume_label, false) {
-                    Ok(_) => {
-                        match iso::get_iso_size(&iso_path) {
-                            Ok(_) => {
-                                info!("Dry run ISO created successfully");
-                            }
-                            Err(e) => {
-                                error!("Failed to get dry run ISO size: {}", e);
-                                let _ = tx.send(DiscCreationMessage::Error(format!("Failed to verify dry run ISO: {}", e)));
-                                return Err(anyhow::anyhow!("Failed to get dry run ISO size: {}", e));
-                            }
+                    Ok(_) => match iso::get_iso_size(&iso_path) {
+                        Ok(_) => {
+                            info!("Dry run ISO created successfully");
                         }
-                    }
+                        Err(e) => {
+                            error!("Failed to get dry run ISO size: {}", e);
+                            let _ = tx.send(DiscCreationMessage::Error(format!(
+                                "Failed to verify dry run ISO: {}",
+                                e
+                            )));
+                            return Err(anyhow::anyhow!("Failed to get dry run ISO size: {}", e));
+                        }
+                    },
                     Err(e) => {
                         error!("Dry run ISO creation failed: {}", e);
-                        let _ = tx.send(DiscCreationMessage::Error(format!("Dry run ISO creation failed: {}", e)));
+                        let _ = tx.send(DiscCreationMessage::Error(format!(
+                            "Dry run ISO creation failed: {}",
+                            e
+                        )));
                         return Err(anyhow::anyhow!("Dry run ISO creation failed: {}", e));
                     }
                 }
@@ -1570,7 +1647,12 @@ impl App {
             match config.burn.method.as_str() {
                 "direct" => {
                     // Burn the staging directory directly (no ISO needed)
-                    Self::burn_direct_with_progress(&disc_root, &config.device, dry_run, tx.clone())?;
+                    Self::burn_direct_with_progress(
+                        &disc_root,
+                        &config.device,
+                        dry_run,
+                        tx.clone(),
+                    )?;
                 }
                 "iso" | _ => {
                     // Default: create and burn ISO
@@ -1589,7 +1671,16 @@ impl App {
             "Updating index...".to_string(),
         ));
 
-        match Self::index_disc_in_database(&mut db_conn, &disc_id, &volume_label, &notes, iso_size, &config.device, dry_run, &source_roots) {
+        match Self::index_disc_in_database(
+            &mut db_conn,
+            &disc_id,
+            &volume_label,
+            &notes,
+            iso_size,
+            &config.device,
+            dry_run,
+            &source_roots,
+        ) {
             Ok(_) => {
                 let _ = tx.send(DiscCreationMessage::StateAndStatus(
                     tui::new_disc::ProcessingState::Indexing,
@@ -1598,18 +1689,26 @@ impl App {
             }
             Err(e) => {
                 error!("Database indexing failed: {}", e);
-                let _ = tx.send(DiscCreationMessage::Error(format!("Database indexing failed: {}", e)));
+                let _ = tx.send(DiscCreationMessage::Error(format!(
+                    "Database indexing failed: {}",
+                    e
+                )));
                 return Err(anyhow::anyhow!("Database indexing failed: {}", e));
             }
         }
 
         match Self::index_files_in_database(&mut db_conn, &disc_id, &files) {
             Ok(_) => {
-                let _ = tx.send(DiscCreationMessage::Progress("Files indexed in database".to_string()));
+                let _ = tx.send(DiscCreationMessage::Progress(
+                    "Files indexed in database".to_string(),
+                ));
             }
             Err(e) => {
                 error!("File indexing failed: {}", e);
-                let _ = tx.send(DiscCreationMessage::Error(format!("File indexing failed: {}", e)));
+                let _ = tx.send(DiscCreationMessage::Error(format!(
+                    "File indexing failed: {}",
+                    e
+                )));
                 return Err(anyhow::anyhow!("File indexing failed: {}", e));
             }
         }
@@ -1634,7 +1733,9 @@ impl App {
                 }
             }
         } else {
-            let _ = tx.send(DiscCreationMessage::Status("QR code generation disabled".to_string()));
+            let _ = tx.send(DiscCreationMessage::Status(
+                "QR code generation disabled".to_string(),
+            ));
         }
 
         let _ = tx.send(DiscCreationMessage::Complete);
@@ -1642,20 +1743,11 @@ impl App {
     }
 
     /// Safely generate QR code with proper error handling
-    fn generate_qr_code_safely(
-        _config: &Config,
-        disc_id: &str,
-        dry_run: bool,
-    ) -> Result<()> {
-        let qrcodes_dir = paths::qrcodes_dir()
-            .context("Failed to get QR codes directory")?;
+    fn generate_qr_code_safely(_config: &Config, disc_id: &str, dry_run: bool) -> Result<()> {
+        let qrcodes_dir = paths::qrcodes_dir().context("Failed to get QR codes directory")?;
 
-        qrcode::generate_qrcode(
-            disc_id,
-            &qrcodes_dir,
-            qrcode::QrCodeFormat::PNG,
-            dry_run,
-        ).context("QR code generation failed")?;
+        qrcode::generate_qrcode(disc_id, &qrcodes_dir, qrcode::QrCodeFormat::PNG, dry_run)
+            .context("QR code generation failed")?;
 
         Ok(())
     }
@@ -1775,8 +1867,8 @@ fn main() -> Result<()> {
         }
 
         // Check for background messages first (always poll these)
-        let has_background_task = matches!(app.state, AppState::NewDisc(_))
-            && app.disc_creation_rx.is_some();
+        let has_background_task =
+            matches!(app.state, AppState::NewDisc(_)) && app.disc_creation_rx.is_some();
 
         let background_updated = if has_background_task {
             app.poll_background_messages()

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -52,15 +52,17 @@ pub fn generate_manifest_and_sums_with_progress(
 
     if let Some(ref mut callback) = progress_callback {
         let checksum_type = if fast_mode { "CRC32" } else { "SHA256" };
-        callback(&format!("📊 Processing {} files with {} checksums", file_paths.len(), checksum_type));
+        callback(&format!(
+            "📊 Processing {} files with {} checksums",
+            file_paths.len(),
+            checksum_type
+        ));
     }
 
     // Second pass: process files in parallel
     let files: Vec<FileMetadata> = file_paths
         .into_par_iter()
-        .map(|file_path| {
-            generate_file_metadata_parallel(&file_path, base, fast_mode)
-        })
+        .map(|file_path| generate_file_metadata_parallel(&file_path, base, fast_mode))
         .collect::<Result<Vec<_>>>()?;
 
     // Send progress updates for each file (not thread-safe, so do it sequentially)
@@ -72,12 +74,20 @@ pub fn generate_manifest_and_sums_with_progress(
             // Show progress every 10 files or for large files
             if i % 10 == 0 || file.size > 100 * 1024 * 1024 {
                 let size_mb = file.size / (1024 * 1024);
-                callback(&format!("🔐 {} {}/{} ({}MB): {}",
-                                 checksum_type, i + 1, files.len(), size_mb,
-                                 file.rel_path.display()));
+                callback(&format!(
+                    "🔐 {} {}/{} ({}MB): {}",
+                    checksum_type,
+                    i + 1,
+                    files.len(),
+                    size_mb,
+                    file.rel_path.display()
+                ));
             }
         }
-        callback(&format!("✅ Checksum generation complete: {} files processed", files.len()));
+        callback(&format!(
+            "✅ Checksum generation complete: {} files processed",
+            files.len()
+        ));
     }
 
     info!("Generated manifest with {} files", files.len());
@@ -109,7 +119,11 @@ fn generate_file_metadata_parallel(
     base: &Path,
     fast_mode: bool,
 ) -> Result<FileMetadata> {
-    debug!("Processing file: {} (fast_mode: {})", file_path.display(), fast_mode);
+    debug!(
+        "Processing file: {} (fast_mode: {})",
+        file_path.display(),
+        fast_mode
+    );
     let rel_path = crate::paths::make_relative(file_path, base)?;
 
     let metadata = fs::metadata(file_path)
@@ -155,7 +169,6 @@ fn walk_directory(dir: &Path, base: &Path, files: &mut Vec<FileMetadata>) -> Res
 
     Ok(())
 }
-
 
 /// Generate metadata for a single file.
 #[allow(dead_code)]

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -102,7 +102,8 @@ pub fn detect_optical_drive() -> Option<String> {
     }
 
     // Method 2: Scan /dev/sr* devices (most common on modern Linux)
-    for i in 0..10 {  // Check sr0 through sr9
+    for i in 0..10 {
+        // Check sr0 through sr9
         let device_path = format!("/dev/sr{}", i);
         let path = PathBuf::from(&device_path);
         if validate_device_quiet(&path).is_ok() {
@@ -117,7 +118,7 @@ pub fn detect_optical_drive() -> Option<String> {
         "/dev/bluray",
         "/dev/sr",
         "/dev/scd0",
-        "/dev/hdc",  // Older IDE drives
+        "/dev/hdc", // Older IDE drives
         "/dev/hdd",
     ];
 
@@ -164,7 +165,10 @@ pub fn validate_device(path: &Path) -> Result<()> {
         // Suggest auto-detection if the default device doesn't exist
         let suggestion = if path.to_string_lossy() == "/dev/sr0" {
             if let Some(auto_detected) = detect_optical_drive() {
-                format!("\n\n💡 Suggestion: Use auto-detected drive: {}", auto_detected)
+                format!(
+                    "\n\n💡 Suggestion: Use auto-detected drive: {}",
+                    auto_detected
+                )
             } else {
                 "\n\n💡 No optical drives detected on this system.".to_string()
             }

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -43,8 +43,12 @@ pub fn stage_files_with_progress(
 
     if let Some(ref mut callback) = progress_callback {
         let size_mb = total_size_bytes / (1024 * 1024);
-        callback(&format!("📁 Preparing to stage {} files ({}MB) from {} folders",
-                         total_files, size_mb, source_folders.len()));
+        callback(&format!(
+            "📁 Preparing to stage {} files ({}MB) from {} folders",
+            total_files,
+            size_mb,
+            source_folders.len()
+        ));
     }
 
     for (i, source) in source_folders.iter().enumerate() {
@@ -64,27 +68,52 @@ pub fn stage_files_with_progress(
             .unwrap_or("unknown");
 
         if let Some(ref mut callback) = progress_callback {
-            callback(&format!("📂 Staging folder {}/{}: {} ({} files processed so far)",
-                             i + 1, source_folders.len(), folder_name, processed_files));
+            callback(&format!(
+                "📂 Staging folder {}/{}: {} ({} files processed so far)",
+                i + 1,
+                source_folders.len(),
+                folder_name,
+                processed_files
+            ));
         }
 
         let dest = archive_dir.join(folder_name);
 
-    // Enhanced staging with file-by-file progress
-    if use_rsync {
-        stage_with_rsync_progress(source, &dest, dry_run, &mut progress_callback, &mut processed_files)?;
-    } else {
-        stage_with_copy_progress(source, &dest, dry_run, &mut progress_callback, &mut processed_files)?;
-    }
+        // Enhanced staging with file-by-file progress
+        if use_rsync {
+            stage_with_rsync_progress(
+                source,
+                &dest,
+                dry_run,
+                &mut progress_callback,
+                &mut processed_files,
+            )?;
+        } else {
+            stage_with_copy_progress(
+                source,
+                &dest,
+                dry_run,
+                &mut progress_callback,
+                &mut processed_files,
+            )?;
+        }
 
         staged_paths.push(dest);
     }
 
     if let Some(ref mut callback) = progress_callback {
-        callback(&format!("✅ Staging complete: {} folders, {} files processed", staged_paths.len(), processed_files));
+        callback(&format!(
+            "✅ Staging complete: {} folders, {} files processed",
+            staged_paths.len(),
+            processed_files
+        ));
     }
 
-    info!("Staged {} folders, {} files", staged_paths.len(), processed_files);
+    info!(
+        "Staged {} folders, {} files",
+        staged_paths.len(),
+        processed_files
+    );
     Ok(staged_paths)
 }
 
@@ -147,7 +176,11 @@ fn stage_with_rsync_progress(
     }
 
     if let Some(ref mut callback) = progress_callback {
-        callback(&format!("🔄 Running rsync: {} -> {}", source.display(), dest.display()));
+        callback(&format!(
+            "🔄 Running rsync: {} -> {}",
+            source.display(),
+            dest.display()
+        ));
     }
 
     crate::commands::execute_command("rsync", &args, dry_run).context("rsync failed")?;
@@ -179,7 +212,11 @@ fn stage_with_copy_progress(
     );
 
     if dry_run {
-        info!("[DRY RUN] Would copy: {} -> {}", source.display(), dest.display());
+        info!(
+            "[DRY RUN] Would copy: {} -> {}",
+            source.display(),
+            dest.display()
+        );
         // Estimate files processed for dry run
         if let Ok((count, _)) = count_files_and_size(source) {
             *processed_files += count;
@@ -210,11 +247,16 @@ fn stage_with_copy_progress(
                         *files_copied += 1;
 
                         // Report progress for larger files or every 10 files
-                        if *files_copied % 10 == 0 || src_path.metadata()?.len() > 10 * 1024 * 1024 {
+                        if *files_copied % 10 == 0 || src_path.metadata()?.len() > 10 * 1024 * 1024
+                        {
                             if let Some(ref mut callback) = progress_callback {
                                 let size_mb = src_path.metadata()?.len() / (1024 * 1024);
-                                callback(&format!("📄 Copied: {} ({}MB) - {} files total",
-                                                 file_name.to_string_lossy(), size_mb, files_copied));
+                                callback(&format!(
+                                    "📄 Copied: {} ({}MB) - {} files total",
+                                    file_name.to_string_lossy(),
+                                    size_mb,
+                                    files_copied
+                                ));
                             }
                         }
                     } else if src_path.is_dir() {
@@ -229,7 +271,11 @@ fn stage_with_copy_progress(
     }
 
     if let Some(ref mut callback) = progress_callback {
-        callback(&format!("📋 Starting copy: {} -> {}", source.display(), dest.display()));
+        callback(&format!(
+            "📋 Starting copy: {} -> {}",
+            source.display(),
+            dest.display()
+        ));
     }
 
     copy_recursive(source, dest, progress_callback, &mut files_copied)?;
@@ -401,4 +447,3 @@ mod tests {
         Ok(())
     }
 }
-

--- a/src/tui/directory_selector_simple.rs
+++ b/src/tui/directory_selector_simple.rs
@@ -401,7 +401,8 @@ impl DirectorySelector {
         let async_completed = self.check_async_loading();
 
         // Start loading if needed and not already loading
-        let started_loading = if self.entries.is_empty() && self.loading_state == LoadingState::Idle {
+        let started_loading = if self.entries.is_empty() && self.loading_state == LoadingState::Idle
+        {
             self.ensure_entries_loaded().unwrap_or(false)
         } else {
             false
@@ -613,7 +614,10 @@ fn load_directory_entries_sync(current_dir: PathBuf) -> LoadingResult {
                     }
                 }
             }
-            LoadingResult { entries, error: None }
+            LoadingResult {
+                entries,
+                error: None,
+            }
         }
         Err(e) => LoadingResult {
             entries: Vec::new(),

--- a/src/tui/new_disc.rs
+++ b/src/tui/new_disc.rs
@@ -241,13 +241,18 @@ impl NewDiscFlow {
         }
 
         // Check for control characters
-        if disc_id.chars().any(|c| c.is_control() && c != '\n' && c != '\t') {
+        if disc_id
+            .chars()
+            .any(|c| c.is_control() && c != '\n' && c != '\t')
+        {
             return "Disc ID contains invalid control characters".to_string();
         }
 
         // Check for reserved names (basic check)
-        let reserved_names = ["CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4",
-                             "LPT1", "LPT2", "LPT3", "LPT4"];
+        let reserved_names = [
+            "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "LPT1", "LPT2", "LPT3",
+            "LPT4",
+        ];
         if reserved_names.contains(&disc_id.to_uppercase().as_str()) {
             return "Disc ID uses a reserved system name".to_string();
         }
@@ -302,15 +307,13 @@ impl NewDiscFlow {
                 let instructions = if validation_msg.is_empty() {
                     "Type to customize, [Enter] Accept, [Esc] Cancel".to_string()
                 } else {
-                    format!("❌ {} - [Enter] Use default '{}', [Esc] Cancel", validation_msg, self.disc_id)
+                    format!(
+                        "❌ {} - [Enter] Use default '{}', [Esc] Cancel",
+                        validation_msg, self.disc_id
+                    )
                 };
 
-                let text = format!(
-                    "{} {}\n\n{}",
-                    id_label,
-                    display_id,
-                    instructions
-                );
+                let text = format!("{} {}\n\n{}", id_label, display_id, instructions);
                 let para = Paragraph::new(text)
                     .block(block)
                     .style(if validation_msg.is_empty() {


### PR DESCRIPTION
Use cargo to autoformat the codebase. We should probably also make this a regular command LLMs run, but in a separate PR perhaps.